### PR TITLE
Animate warp

### DIFF
--- a/magicmaze.game.php
+++ b/magicmaze.game.php
@@ -570,7 +570,7 @@ class MagicMaze extends Table {
             'player_name' => self::getCurrentPlayerName(),
             'position_x' => $res['position_x'],
             'position_y' => $res['position_y'],
-            'warp' =>false,
+            'warp' => false,
         ));
     }
 
@@ -610,7 +610,7 @@ class MagicMaze extends Table {
             'player_name' => self::getCurrentPlayerName(),
             'position_x' => $res['position_x'],
             'position_y' => $res['position_y'],
-            'warp' =>false,
+            'warp' => false,
         ));
         if ($this->delayedNotification !== null) {
             self::notifyAllPlayers(

--- a/magicmaze.game.php
+++ b/magicmaze.game.php
@@ -546,6 +546,7 @@ class MagicMaze extends Table {
             'player_name' => self::getCurrentPlayerName(),
             'position_x' => $res['position_x'],
             'position_y' => $res['position_y'],
+            'warp' => true,
         ));
     }
 
@@ -569,6 +570,7 @@ class MagicMaze extends Table {
             'player_name' => self::getCurrentPlayerName(),
             'position_x' => $res['position_x'],
             'position_y' => $res['position_y'],
+            'warp' =>false,
         ));
     }
 
@@ -608,6 +610,7 @@ class MagicMaze extends Table {
             'player_name' => self::getCurrentPlayerName(),
             'position_x' => $res['position_x'],
             'position_y' => $res['position_y'],
+            'warp' =>false,
         ));
         if ($this->delayedNotification !== null) {
             self::notifyAllPlayers(

--- a/magicmaze.js
+++ b/magicmaze.js
@@ -674,17 +674,17 @@ function placeCharacter (obj, info, warp = false) {
     halftime = 300
   }
   obj.rescale(1.0)
-  obj.slideToObjectPos(
+  const slide = obj.slideToObjectPos(
     `mm_token${info.token_id}`,
     'mm_area_scrollable_oversurface',
     left + adjust,
     top + adjust,
-    2*halftime).play()
+    2*halftime)
+  slide.play()
   if (warp) {
     const tokenEl = dojo.query(`#mm_token${info.token_id}`)
     const distance = Math.sqrt((x - oldx)*(x - oldx) + (y - oldy)*(y - oldy))
     const scale = Math.min(5, Math.max(1, Math.sqrt(distance)))
-    const stored_obj = obj
     dojo.connect(slide, "onEnd", async function(){
       tokenEl.style('transition', `${2*halftime}ms`)
       tokenEl.style('transform', 'scale(1)')

--- a/magicmaze.js
+++ b/magicmaze.js
@@ -657,21 +657,55 @@ function drawMagePreviews (obj) {
   }
 }
 
+
+
 function placeCharacter (obj, info, warp = false) {
   const x = parseInt(info.position_x)
   const y = parseInt(info.position_y)
   const tokenId = parseInt(info.token_id)
+  const [oldx, oldy] = obj.characterLocs.get(tokenId) ?? [x, y]
   obj.characterLocs.set(tokenId, [x, y])
   const key = getKey(x, y)
   const top = obj.tops.get(key)
   const left = obj.lefts.get(key)
   const adjust = (CELL_SIZE - MEEPLE_SIZE) / 2
+  var halftime = 100
+  if (warp) {
+    halftime = 300
+  }
   obj.rescale(1.0)
-  obj.slideToObjectPos(`mm_token${info.token_id}`,
+  obj.slideToObjectPos(
+    `mm_token${info.token_id}`,
     'mm_area_scrollable_oversurface',
     left + adjust,
     top + adjust,
-    /* duration */ 200).play()
+    2*halftime).play()
+  if (warp) {
+    const tokenEl = dojo.query(`#mm_token${info.token_id}`)
+    const distance = Math.sqrt((x - oldx)*(x - oldx) + (y - oldy)*(y - oldy))
+    const scale = Math.min(5, Math.max(1, Math.sqrt(distance)))
+    const stored_obj = obj
+    dojo.connect(slide, "onEnd", async function(){
+      tokenEl.style('transition', `${2*halftime}ms`)
+      tokenEl.style('transform', 'scale(1)')
+      // If a player moves a token during the warp animation the end position
+      // ends up wrong due to the interaction of CSS scaling and dojo
+      // animation (the docs rightfully warn of this; however we need to take
+      // this downside here to achieve the desired grow and shrink effect). To
+      // ameliorate this we reposition the token after the animations are
+      // done.
+      await obj.wait(2*halftime)
+      const [newx, newy] = obj.characterLocs.get(tokenId)
+      const newinfo = {
+        position_x: newx,
+        position_y: newy,
+        token_id: tokenId
+      }
+      placeCharacter(obj, newinfo)
+    });
+    tokenEl.style('transition', `${2.5*halftime}ms`)
+    tokenEl.style('transform', `scale(${scale})`)
+  }
   obj.rescale()
   destroyPreviews(obj, tokenId)
 

--- a/magicmaze.js
+++ b/magicmaze.js
@@ -657,7 +657,7 @@ function drawMagePreviews (obj) {
   }
 }
 
-function placeCharacter (obj, info) {
+function placeCharacter (obj, info, warp = false) {
   const x = parseInt(info.position_x)
   const y = parseInt(info.position_y)
   const tokenId = parseInt(info.token_id)
@@ -1100,7 +1100,7 @@ function (dojo, declare) {
       }
     },
     notif_tokenMoved: function (notif) {
-      placeCharacter(this, notif.args)
+      placeCharacter(this, notif.args, /* warp= */ notif.args.warp)
     },
     notif_nextTile: function (notif) {
       this.mageStatus = parseInt(notif.args.mage_status, 10)

--- a/magicmaze.js
+++ b/magicmaze.js
@@ -677,7 +677,6 @@ function placeCharacter (obj, info, warp = false) {
     left + adjust,
     top + adjust,
     animtime)
-  slide.play()
   if (warp) {
     const tokenEl = dojo.query(`#mm_token${info.token_id}`)
     const distance = Math.sqrt((x - oldx)*(x - oldx) + (y - oldy)*(y - oldy))
@@ -703,6 +702,7 @@ function placeCharacter (obj, info, warp = false) {
     tokenEl.style('transition', `${1.25*animtime}ms`)
     tokenEl.style('transform', `scale(${scale})`)
   }
+  slide.play()
   obj.rescale()
   destroyPreviews(obj, tokenId)
 

--- a/magicmaze.js
+++ b/magicmaze.js
@@ -697,7 +697,7 @@ function placeCharacter (obj, info, warp = false) {
         position_y: newy,
         token_id: tokenId
       }
-      placeCharacter(obj, newinfo)
+      placeCharacter(obj, newinfo, /* warp = */ false)
     });
     tokenEl.style('transition', `${1.25*animtime}ms`)
     tokenEl.style('transform', `scale(${scale})`)

--- a/magicmaze.js
+++ b/magicmaze.js
@@ -678,6 +678,20 @@ function placeCharacter (obj, info, warp = false) {
     top + adjust,
     animtime)
   if (warp) {
+    // The following animation should vaguely look like picking up the token
+    // and placing it somewhere else.
+    //
+    // However the actual result differs from the expectation after reading
+    // the code. The main divergence seems to be that the onEnd-effect does
+    // trigger before the token reaches the target field. The final animation
+    // comes reasonably close to the goal above so that this feels like a good
+    // result.
+    //
+    // The weirdness probably is a side-effect of mixing dojo animations with
+    // CSS-transforms. Sadly no other way presented itself to reach the
+    // desired effect.
+    //
+    // Also note that the token seems to wobble if the zoom level is not 100%.
     const tokenEl = dojo.query(`#mm_token${info.token_id}`)
     const distance = Math.sqrt((x - oldx)*(x - oldx) + (y - oldy)*(y - oldy))
     const scale = Math.min(5, Math.max(1, Math.sqrt(distance)))

--- a/magicmaze.js
+++ b/magicmaze.js
@@ -669,24 +669,21 @@ function placeCharacter (obj, info, warp = false) {
   const top = obj.tops.get(key)
   const left = obj.lefts.get(key)
   const adjust = (CELL_SIZE - MEEPLE_SIZE) / 2
-  var halftime = 100
-  if (warp) {
-    halftime = 300
-  }
+  const animtime = warp ? 600 : 200
   obj.rescale(1.0)
   const slide = obj.slideToObjectPos(
     `mm_token${info.token_id}`,
     'mm_area_scrollable_oversurface',
     left + adjust,
     top + adjust,
-    2*halftime)
+    animtime)
   slide.play()
   if (warp) {
     const tokenEl = dojo.query(`#mm_token${info.token_id}`)
     const distance = Math.sqrt((x - oldx)*(x - oldx) + (y - oldy)*(y - oldy))
     const scale = Math.min(5, Math.max(1, Math.sqrt(distance)))
     dojo.connect(slide, "onEnd", async function(){
-      tokenEl.style('transition', `${2*halftime}ms`)
+      tokenEl.style('transition', `${animtime}ms`)
       tokenEl.style('transform', 'scale(1)')
       // If a player moves a token during the warp animation the end position
       // ends up wrong due to the interaction of CSS scaling and dojo
@@ -694,7 +691,7 @@ function placeCharacter (obj, info, warp = false) {
       // this downside here to achieve the desired grow and shrink effect). To
       // ameliorate this we reposition the token after the animations are
       // done.
-      await obj.wait(2*halftime)
+      await obj.wait(animtime)
       const [newx, newy] = obj.characterLocs.get(tokenId)
       const newinfo = {
         position_x: newx,
@@ -703,7 +700,7 @@ function placeCharacter (obj, info, warp = false) {
       }
       placeCharacter(obj, newinfo)
     });
-    tokenEl.style('transition', `${2.5*halftime}ms`)
+    tokenEl.style('transition', `${1.25*animtime}ms`)
     tokenEl.style('transform', `scale(${scale})`)
   }
   obj.rescale()


### PR DESCRIPTION
Closes #7.

This now works quite close to what I envisioned. Sadly dojo seems to be unable to animate the scale property so that I had to use a CSS transform and mix them. This can lead to misplaced tokens if they are moved during a warp. I added a fixup placement so that this is only a temporary problem.
The only remaining issue that I don't really understand is that if the zoom level is not neutral the warped token seems to wobble. However this seems tolerable.