### PR TITLE
WIP: Exception on call to set status bar.

### DIFF
--- a/magicmaze.js
+++ b/magicmaze.js
@@ -1186,6 +1186,7 @@ function (dojo, declare) {
     },
     notif_tokenMoved: function (notif) {
       placeCharacter(this, notif.args, /* warp= */ notif.args.warp)
+      this.statusBar.setTitle(_('XXX Test message to try functionality.'))
     },
     notif_nextTile: function (notif) {
       this.mageStatus = parseInt(notif.args.mage_status, 10)


### PR DESCRIPTION
I tried manipulating the status bar to implement #6 , but I always get a nasty exception when calling the setTitle function. I distilled this to the example in this branch, hooking it up to the tokenMoved notification to make it easily triggerable. I always observed the same behavior.  When triggered the framework blows up with the backtrace below. It seems to have trouble with the active player ("i" should hold the data of the active player if I understand this correctly). I just called it as [1] suggested and I'm a bit stymied by the error. Do you have any clue what's going on here and how to go about this? Or is this maybe even a bug in the framework and I may need to escalate this further?

```
During notification tokenMoved
can't access property "color_back", i is undefined
getFormattedPlayerName@https://studio.boardgamearena.com:8084/data/themereleases/250904-0918/js/modules/layer/ly_studio.js:1:541137
setTitle@https://studio.boardgamearena.com:8084/data/themereleases/250904-0918/js/modules/layer/ly_studio.js:1:486222
notif_tokenMoved@https://studio.boardgamearena.com:8084/data/themereleases/current/games/magicmaze/999999-9999/magicmaze.js:1189:22
```

[1] https://en.doc.boardgamearena.com/Game_interface_logic:_yourgamename.js#Title_bar_and_states